### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- Add Dependabot configuration for automated dependency updates
- Configure weekly updates for NuGet packages
- Configure weekly updates for GitHub Actions

## Details

This keeps the repository dependencies up to date automatically by:
- Opening PRs for outdated NuGet packages (limit: 10 open PRs)
- Opening PRs for outdated GitHub Actions (limit: 5 open PRs)

## Test plan

- [ ] Verify Dependabot detects the configuration
- [ ] Check that dependency update PRs are created on schedule