### PR TITLE
fix: remove deprecated WithOpenApi() for Swashbuckle v10 compatibility

### DIFF
--- a/SimpleWebApi/Program.cs
+++ b/SimpleWebApi/Program.cs
@@ -33,8 +33,7 @@ app.MapGet("/weatherforecast", () =>
         .ToArray();
     return forecast;
 })
-.WithName("GetWeatherForecast")
-.WithOpenApi();
+.WithName("GetWeatherForecast");
 
 app.Run();
 


### PR DESCRIPTION
## Summary

Fixes the build failure caused by the Swashbuckle.AspNetCore v10 upgrade (PR #11).

## Problem

After merging `dependabot/nuget/SimpleWebApi/Swashbuckle.AspNetCore-10.1.0`, both tests fail with:
```
System.Net.Http.HttpRequestException : Response status code does not indicate success: 500 (Internal Server Error)
```

## Root Cause

Swashbuckle.AspNetCore v10 no longer supports the `WithOpenApi()` extension method from `Microsoft.AspNetCore.OpenApi`. From the [migration guide](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/master/docs/migrating-to-v10.md):

> Remove any use of the now-deprecated WithOpenApi() extension method

## Fix

Remove the `.WithOpenApi()` call from the endpoint definition. Swagger documentation still works via `AddSwaggerGen()` and `AddEndpointsApiExplorer()`.

## Test plan

- [ ] Build succeeds
- [ ] Tests pass
- [ ] Swagger UI still accessible at `/swagger`