### PR TITLE
fix: resolve CS8602 nullable reference warnings in tests

### DIFF
--- a/SimpleWebApi.Test/WebApiTest.cs
+++ b/SimpleWebApi.Test/WebApiTest.cs
@@ -23,8 +23,8 @@ public class WebApiTest : IClassFixture<WebApplicationFactory<Program>>
 
         // Assert
         response.EnsureSuccessStatusCode(); // Status Code 200-299
-        Assert.Equal("application/json; charset=utf-8", 
-            response.Content.Headers.ContentType.ToString());
+        Assert.Equal("application/json; charset=utf-8",
+            response.Content.Headers.ContentType?.ToString());
     }
 
     [Fact]
@@ -38,7 +38,7 @@ public class WebApiTest : IClassFixture<WebApplicationFactory<Program>>
 
         // Assert
         response.EnsureSuccessStatusCode(); // Status Code 200-299
-        Assert.Equal("text/html; charset=utf-8", 
-            response.Content.Headers.ContentType.ToString());
+        Assert.Equal("text/html; charset=utf-8",
+            response.Content.Headers.ContentType?.ToString());
     }
 }


### PR DESCRIPTION
## Summary

Fixes the 2 compiler warnings that appear during build:

```
WebApiTest.cs(27,13): warning CS8602: Dereference of a possibly null reference.
WebApiTest.cs(42,13): warning CS8602: Dereference of a possibly null reference.
```

## Fix

Use the null-conditional operator (`?.`) on `ContentType` which may be null:

```csharp
// Before
response.Content.Headers.ContentType.ToString()

// After
response.Content.Headers.ContentType?.ToString()
```

## Test plan

- [ ] Build succeeds with 0 warnings
- [ ] Tests pass